### PR TITLE
chore: Upgrade Python and dependencies

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.14"
     - name: Install dependencies
       env:
         REQUIREMENTS_FILE: lint
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.14"
     - name: Install dependencies
       env:
         REQUIREMENTS_FILE: typecheck
@@ -77,7 +77,7 @@ jobs:
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.14"
     - name: Create Google Cloud Service Account Key
       run: |
         echo '${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}' > /tmp/google-service-account.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.12-alpine AS build
-RUN python3.12 -m pip install --upgrade pip setuptools wheel
+FROM python:3.14-alpine AS build
+RUN python3.14 -m pip install --upgrade pip "setuptools>=83.0.0" "wheel>=0.47.0"
 
 WORKDIR /app
 COPY setup.cfg .
@@ -7,16 +7,16 @@ COPY setup.py .
 COPY src ./src
 RUN apk add --no-cache --virtual .build-deps gcc libc-dev libxslt-dev libpq-dev && \
     apk add --no-cache libxslt && \
-    python3.12 -m pip install --disable-pip-version-check -e . && \
+    python3.14 -m pip install --disable-pip-version-check -e . && \
     apk del .build-deps
 
-FROM python:3.12-alpine AS runtime
+FROM python:3.14-alpine AS runtime
 
 # Copy GOOGLE_APPLICATION_CREDENTIALS to the container
 COPY google-service-account.json /tmp/google-service-account.json
 
-COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=build /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
 COPY --from=build /app /app
 WORKDIR /app/src
 
-ENTRYPOINT ["python3.12", "main.py"]
+ENTRYPOINT ["python3.14", "main.py"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,29 +20,29 @@ project_urls =
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >=3.12
+python_requires = >=3.14
 setup_requires =
-    setuptools>=60.2.0
-    wheel>=0.37.1
+    setuptools>=83.0.0
+    wheel>=0.47.0
 install_requires =
-    SQLAlchemy>=2.0.35
-    aiohttp>=3.10.5
-    psycopg[binary,pool]>=3.2.2
-    beautifulsoup4>=4.13.0b2
-    pyfcm>=2.0.7
+    SQLAlchemy>=2.0.51
+    aiohttp>=3.14.1
+    psycopg[binary,pool]>=3.3.4
+    beautifulsoup4>=4.15.0
+    pyfcm>=2.1.0
 zip_safe = false
 include_package_data = true
 
 [options.extras_require]
 dev =
 lint =
-    flake8>=7.0.0
+    flake8>=7.3.0
 typecheck =
-    mypy>=1.9.0
-    sqlalchemy[mypy]>=2.0.29
+    mypy>=2.3.0
+    sqlalchemy[mypy]>=2.0.51
 test =
-    pytest>=8.1.1
-    pytest-asyncio>=0.23.6
+    pytest>=9.1.1
+    pytest-asyncio>=1.4.0
 [mypy]
 plugins = sqlalchemy.ext.mypy.plugin
 ignore_missing_imports = true


### PR DESCRIPTION
## Summary

- Raise the supported runtime from Python 3.13 to Python 3.14.
- Upgrade SQLAlchemy, aiohttp, Beautiful Soup, PyFCM, and packaging dependencies.
- Upgrade pytest, pytest-asyncio, mypy, and flake8.
- Align the Docker image and GitHub Actions environment with Python 3.14.

## Test plan

- [x] Install runtime and development dependencies on Python 3.14
- [x] Run flake8 and mypy
- [x] Build the wheel without resolving dependencies
- [x] GitHub Actions lint, type-check, and database-backed tests
