### PR TITLE
fix: Handle temporary library API failures

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,8 @@ exclude = .git,.cache,.idea,.egg,__pycache__,venv,build,docs,alembic
 [tool:pytest]
 testpaths = tests
 pythonpath = src
+markers =
+    integration: tests that require live external services
 filterwarnings =
     ignore::DeprecationWarning:aioredis.*:
 

--- a/src/scripts/realtime.py
+++ b/src/scripts/realtime.py
@@ -1,7 +1,10 @@
+import asyncio
 import datetime
+import json
 import os
+from typing import Any
 
-from aiohttp import ClientTimeout, ClientSession
+from aiohttp import ClientError, ClientTimeout, ClientSession
 from pyfcm import FCMNotification
 from sqlalchemy import insert
 from sqlalchemy.orm import Session
@@ -14,52 +17,101 @@ push_service = FCMNotification(
     project_id=google_project_id,
 )
 
+LIBRARY_API_TIMEOUT_SECONDS = 10
+LIBRARY_API_MAX_ATTEMPTS = 3
+LIBRARY_API_RETRYABLE_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+
+def _response_summary(response_text: str, limit: int = 200) -> str:
+    summary = " ".join(response_text.split())
+    return summary[:limit]
+
+
+async def _get_json(url: str) -> dict[str, Any]:
+    timeout = ClientTimeout(total=LIBRARY_API_TIMEOUT_SECONDS)
+    async with ClientSession(timeout=timeout, headers={"Accept": "application/json"}) as session:
+        for attempt in range(1, LIBRARY_API_MAX_ATTEMPTS + 1):
+            try:
+                async with session.get(url) as response:
+                    response_text = await response.text()
+                    if response.status >= 400:
+                        summary = _response_summary(response_text)
+                        message = f"Library API returned HTTP {response.status} for {url}"
+                        if summary:
+                            message = f"{message}: {summary}"
+                        if (
+                            response.status not in LIBRARY_API_RETRYABLE_STATUSES
+                            or attempt == LIBRARY_API_MAX_ATTEMPTS
+                        ):
+                            raise RuntimeError(message)
+                    else:
+                        content_type = response.headers.get("Content-Type", "").lower()
+                        if "json" not in content_type:
+                            raise RuntimeError(
+                                f"Library API returned non-JSON content ({content_type or 'unknown'}) for {url}"
+                            )
+                        try:
+                            response_json = json.loads(response_text)
+                        except json.JSONDecodeError as error:
+                            raise RuntimeError(f"Library API returned invalid JSON for {url}") from error
+                        if not isinstance(response_json, dict):
+                            raise RuntimeError(f"Library API returned an invalid JSON root for {url}")
+                        return response_json
+            except (ClientError, TimeoutError) as error:
+                if attempt == LIBRARY_API_MAX_ATTEMPTS:
+                    raise RuntimeError(
+                        f"Library API request failed after {LIBRARY_API_MAX_ATTEMPTS} attempts for {url}: {error}"
+                    ) from error
+
+            delay = 2 ** (attempt - 1)
+            print(
+                f"Library API request attempt {attempt}/{LIBRARY_API_MAX_ATTEMPTS} failed for {url}; "
+                f"retrying in {delay}s"
+            )
+            await asyncio.sleep(delay)
+
+    raise RuntimeError(f"Library API request failed for {url}")
+
 
 async def get_branches() -> dict[int, int]:
     url = "https://library.hanyang.ac.kr/pyxis-api/1/branches"
-    timeout = ClientTimeout(total=30)
-    async with ClientSession(timeout=timeout) as session:
-        async with session.get(url) as response:
-            response_json = await response.json()
-            branch_list = response_json["data"]["list"]
-            return {branch["id"]: branch["branchGroup"]["id"] for branch in branch_list}
+    response_json = await _get_json(url)
+    branch_list = response_json["data"]["list"]
+    return {branch["id"]: branch["branchGroup"]["id"] for branch in branch_list}
 
 
 async def get_realtime_data(db_session: Session, campus_id: int) -> None:
-    timeout = ClientTimeout(total=30)
     room_items: list[dict] = []
     now = datetime.datetime.now()
     url = f"https://library.hanyang.ac.kr/pyxis-api/{campus_id}/seat-rooms?smufMethodCode=PC&branchGroupId={campus_id}"
-    async with ClientSession(timeout=timeout) as session:
-        async with session.get(url) as response:
-            response_json = await response.json()
-            if response_json.get("data") is None:
-                return
-            room_list = response_json["data"]["list"]
-            for room in room_list:
-                seats = room["seats"]
-                if seats["available"] > 0:
-                    data = {
-                        "body": f"{room['name']}에 좌석이 {seats['available']}개 남았습니다.",
-                        "title": "열람실 좌석 발견!",
-                        "id": f'reading_room_{room["id"]}',
-                        "available": str(seats['total'] - seats['occupied']),
-                    }
-                    push_service.notify(
-                        topic_name=f"reading_room_{room['id']}",
-                        data_payload=data,
-                    )
-                room_items.append(dict(
-                    campus_id=campus_id,
-                    room_id=room["id"],
-                    room_name=room["name"],
-                    is_active=True,
-                    is_reservable=room["unableMessage"] is None,
-                    total=seats["total"],
-                    active_total=seats["total"],
-                    occupied=seats["occupied"],
-                    last_updated_time=now.astimezone(datetime.timezone(datetime.timedelta(hours=9))),
-                ))
+    response_json = await _get_json(url)
+    if response_json.get("data") is None:
+        return
+    room_list = response_json["data"]["list"]
+    for room in room_list:
+        seats = room["seats"]
+        if seats["available"] > 0:
+            data = {
+                "body": f"{room['name']}에 좌석이 {seats['available']}개 남았습니다.",
+                "title": "열람실 좌석 발견!",
+                "id": f'reading_room_{room["id"]}',
+                "available": str(seats['total'] - seats['occupied']),
+            }
+            push_service.notify(
+                topic_name=f"reading_room_{room['id']}",
+                data_payload=data,
+            )
+        room_items.append(dict(
+            campus_id=campus_id,
+            room_id=room["id"],
+            room_name=room["name"],
+            is_active=True,
+            is_reservable=room["unableMessage"] is None,
+            total=seats["total"],
+            active_total=seats["total"],
+            occupied=seats["occupied"],
+            last_updated_time=now.astimezone(datetime.timezone(datetime.timedelta(hours=9))),
+        ))
     if room_items:
         db_session.execute(insert(ReadingRoom), room_items)
     db_session.commit()

--- a/tests/test_fetch_reading_room_data.py
+++ b/tests/test_fetch_reading_room_data.py
@@ -8,6 +8,7 @@ from scripts.realtime import get_realtime_data
 from utils.database import get_db_engine
 
 
+@pytest.mark.integration
 class TestFetchReadingRoomData:
     connection: Engine | None = None
     session_constructor = None

--- a/tests/test_library_api.py
+++ b/tests/test_library_api.py
@@ -1,0 +1,91 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import ClientConnectionError
+
+from scripts.realtime import _get_json
+
+
+def make_response(status: int, content_type: str, body: str) -> MagicMock:
+    response = MagicMock()
+    response.status = status
+    response.headers = {"Content-Type": content_type}
+    response.text = AsyncMock(return_value=body)
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=None)
+    return response
+
+
+def make_session(*responses: object) -> MagicMock:
+    session = MagicMock()
+    session.get.side_effect = responses
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=None)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_get_json_retries_503_response() -> None:
+    unavailable = make_response(503, "text/html; charset=iso-8859-1", "<html>Unavailable</html>")
+    success = make_response(200, "application/json; charset=utf-8", '{"data": {"list": []}}')
+    session = make_session(unavailable, success)
+
+    with (
+        patch("scripts.realtime.ClientSession", return_value=session),
+        patch("scripts.realtime.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        response_json = await _get_json("https://example.com/branches")
+
+    assert response_json == {"data": {"list": []}}
+    assert session.get.call_count == 2
+    sleep.assert_awaited_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_get_json_retries_connection_error() -> None:
+    success = make_response(200, "application/json", '{"data": {"list": []}}')
+    session = make_session(ClientConnectionError("connection closed"), success)
+
+    with (
+        patch("scripts.realtime.ClientSession", return_value=session),
+        patch("scripts.realtime.asyncio.sleep", new=AsyncMock()) as sleep,
+    ):
+        response_json = await _get_json("https://example.com/branches")
+
+    assert response_json == {"data": {"list": []}}
+    assert session.get.call_count == 2
+    sleep.assert_awaited_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_get_json_fails_after_repeated_503_responses() -> None:
+    responses = [
+        make_response(503, "text/html; charset=iso-8859-1", "<html>Unavailable</html>") for _ in range(3)
+    ]
+    session = make_session(*responses)
+
+    with (
+        patch("scripts.realtime.ClientSession", return_value=session),
+        patch("scripts.realtime.asyncio.sleep", new=AsyncMock()) as sleep,
+        pytest.raises(RuntimeError, match="Library API returned HTTP 503"),
+    ):
+        await _get_json("https://example.com/branches")
+
+    assert session.get.call_count == 3
+    assert sleep.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_json_rejects_successful_html_response_without_retrying() -> None:
+    response = make_response(200, "text/html; charset=utf-8", "<html>Login</html>")
+    session = make_session(response)
+
+    with (
+        patch("scripts.realtime.ClientSession", return_value=session),
+        patch("scripts.realtime.asyncio.sleep", new=AsyncMock()) as sleep,
+        pytest.raises(RuntimeError, match="Library API returned non-JSON content"),
+    ):
+        await _get_json("https://example.com/branches")
+
+    session.get.assert_called_once()
+    sleep.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Check library API status and content type before decoding JSON.
- Retry temporary HTTP and connection failures with bounded exponential backoff.
- Add focused tests for recovery, repeated 503 responses, connection failures, and unexpected HTML.
- Classify the existing live API and database test as an integration test so unit CI does not depend on external availability.

## Root cause

The library API can return an HTTP 503 response with an HTML body. The updater attempted to decode every response as JSON, which raised `aiohttp.ContentTypeError` before the actual upstream status could be handled. The existing CI test also called the live API despite the workflow excluding tests marked as integration.

## Test plan

- [x] Run `pytest -m 'not integration'`
- [x] Run flake8
- [x] Run mypy
- [x] Verify the diff with `git diff --check`
